### PR TITLE
Automatic update of SonarAnalyzer.CSharp to 9.28.0.94264

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.27.0.93347" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.28.0.94264" PrivateAssets="all" Condition="$(MSBuildProjectExtension) == '.csproj'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SonarAnalyzer.CSharp` to `9.28.0.94264` from `9.27.0.93347`
`SonarAnalyzer.CSharp 9.28.0.94264` was published at `2024-06-26T15:39:21Z`, 9 days ago

1 project update:
Updated `Directory.Build.props` to `SonarAnalyzer.CSharp` `9.28.0.94264` from `9.27.0.93347`

[SonarAnalyzer.CSharp 9.28.0.94264 on NuGet.org](https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.28.0.94264)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
