### PR TITLE
Automatic update of Microsoft.VisualStudio.Azure.Containers.Tools.Targets to 1.21.0

### DIFF
--- a/HomeBudgetIdentityApi/HomeBudgetIdentityApi.csproj
+++ b/HomeBudgetIdentityApi/HomeBudgetIdentityApi.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` to `1.21.0` from `1.20.1`
`Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.21.0` was published at `2024-06-28T18:41:38Z`, 7 days ago

1 project update:
Updated `HomeBudgetIdentityApi/HomeBudgetIdentityApi.csproj` to `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` `1.21.0` from `1.20.1`

[Microsoft.VisualStudio.Azure.Containers.Tools.Targets 1.21.0 on NuGet.org](https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Containers.Tools.Targets/1.21.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
