### PR TITLE
Automatic update of Microsoft.AspNetCore.Authentication.JwtBearer to 8.0.7

### DIFF
--- a/HomeBudget.Identity.Api/HomeBudget.Identity.Api.csproj
+++ b/HomeBudget.Identity.Api/HomeBudget.Identity.Api.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Authentication.JwtBearer` to `8.0.7` from `8.0.6`
`Microsoft.AspNetCore.Authentication.JwtBearer 8.0.7` was published at `2024-07-09T13:12:05Z`, 7 days ago

1 project update:
Updated `HomeBudget.Identity.Api/HomeBudget.Identity.Api.csproj` to `Microsoft.AspNetCore.Authentication.JwtBearer` `8.0.7` from `8.0.6`

[Microsoft.AspNetCore.Authentication.JwtBearer 8.0.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Authentication.JwtBearer/8.0.7)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
