### PR TITLE
Automatic update of Microsoft.AspNetCore.Mvc.Testing to 8.0.7

### DIFF
--- a/HomeBudget.Identity.Api.IntegrationTests/HomeBudget.Identity.Api.IntegrationTests.csproj
+++ b/HomeBudget.Identity.Api.IntegrationTests/HomeBudget.Identity.Api.IntegrationTests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="NUnit" Version="4.1.0" />


### PR DESCRIPTION
NuKeeper has generated a patch update of `Microsoft.AspNetCore.Mvc.Testing` to `8.0.7` from `8.0.6`
`Microsoft.AspNetCore.Mvc.Testing 8.0.7` was published at `2024-07-09T13:20:01Z`, 7 days ago

1 project update:
Updated `HomeBudget.Identity.Api.IntegrationTests/HomeBudget.Identity.Api.IntegrationTests.csproj` to `Microsoft.AspNetCore.Mvc.Testing` `8.0.7` from `8.0.6`

[Microsoft.AspNetCore.Mvc.Testing 8.0.7 on NuGet.org](https://www.nuget.org/packages/Microsoft.AspNetCore.Mvc.Testing/8.0.7)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
