### PR TITLE
Automatic update of RestSharp to 111.4.0

### DIFF
--- a/HomeBudget.Identity.Api.IntegrationTests/HomeBudget.Identity.Api.IntegrationTests.csproj
+++ b/HomeBudget.Identity.Api.IntegrationTests/HomeBudget.Identity.Api.IntegrationTests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="RestSharp" Version="111.3.0" />
+    <PackageReference Include="RestSharp" Version="111.4.0" />
     <PackageReference Include="Testcontainers" Version="3.9.0" />
     <PackageReference Include="Testcontainers.MongoDb" Version="3.9.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `RestSharp` to `111.4.0` from `111.3.0`
`RestSharp 111.4.0` was published at `2024-07-11T17:39:09Z`, 7 days ago

1 project update:
Updated `HomeBudget.Identity.Api.IntegrationTests/HomeBudget.Identity.Api.IntegrationTests.csproj` to `RestSharp` `111.4.0` from `111.3.0`

[RestSharp 111.4.0 on NuGet.org](https://www.nuget.org/packages/RestSharp/111.4.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
