### PR TITLE
Automatic update of Microsoft.IdentityModel.Tokens to 8.0.1

### DIFF
--- a/HomeBudget.Identity.Domain/HomeBudget.Identity.Domain.csproj
+++ b/HomeBudget.Identity.Domain/HomeBudget.Identity.Domain.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.0.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.6.2" />
     <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.IdentityModel.Tokens` to `8.0.1` from `7.6.2`
`Microsoft.IdentityModel.Tokens 8.0.1` was published at `2024-07-23T00:15:46Z`, 7 days ago

1 project update:
Updated `HomeBudget.Identity.Domain/HomeBudget.Identity.Domain.csproj` to `Microsoft.IdentityModel.Tokens` `8.0.1` from `7.6.2`

[Microsoft.IdentityModel.Tokens 8.0.1 on NuGet.org](https://www.nuget.org/packages/Microsoft.IdentityModel.Tokens/8.0.1)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
