### PR TITLE
Automatic update of MongoDB.Bson to 2.28.0

### DIFF
--- a/HomeBudget.Identity.Infrastructure/HomeBudget.Identity.Infrastructure.csproj
+++ b/HomeBudget.Identity.Infrastructure/HomeBudget.Identity.Infrastructure.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.27.0" />
+    <PackageReference Include="MongoDB.Bson" Version="2.28.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
   </ItemGroup>
 


### PR DESCRIPTION
NuKeeper has generated a minor update of `MongoDB.Bson` to `2.28.0` from `2.27.0`
`MongoDB.Bson 2.28.0` was published at `2024-07-23T19:44:37Z`, 7 days ago

1 project update:
Updated `HomeBudget.Identity.Infrastructure/HomeBudget.Identity.Infrastructure.csproj` to `MongoDB.Bson` `2.28.0` from `2.27.0`

[MongoDB.Bson 2.28.0 on NuGet.org](https://www.nuget.org/packages/MongoDB.Bson/2.28.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
