### PR TITLE
Automatic update of MongoDB.Driver to 2.28.0

### DIFF
--- a/HomeBudget.Identity.Infrastructure/HomeBudget.Identity.Infrastructure.csproj
+++ b/HomeBudget.Identity.Infrastructure/HomeBudget.Identity.Infrastructure.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Bson" Version="2.27.0" />
-    <PackageReference Include="MongoDB.Driver" Version="2.27.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.28.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `MongoDB.Driver` to `2.28.0` from `2.27.0`
`MongoDB.Driver 2.28.0` was published at `2024-07-23T19:44:40Z`, 7 days ago

1 project update:
Updated `HomeBudget.Identity.Infrastructure/HomeBudget.Identity.Infrastructure.csproj` to `MongoDB.Driver` `2.28.0` from `2.27.0`

[MongoDB.Driver 2.28.0 on NuGet.org](https://www.nuget.org/packages/MongoDB.Driver/2.28.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
